### PR TITLE
do not use JCenter on new projects.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,8 +2,9 @@
 
 buildscript {
     repositories {
-        jcenter()
         google()
+        mavenCentral()
+        // jcenter() // deprecated
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.5.3'
@@ -15,8 +16,9 @@ buildscript {
 
 allprojects {
     repositories {
-        jcenter()
         google()
+        mavenCentral()
+        // jcenter() // deprecated
     }
 }
 


### PR DESCRIPTION
due to [Google](https://developer.android.com/studio/build/jcenter-migration) recommendations, JCenter should not be used on new projects, developers should migrate to another artifact repository such as maven central, this is the default configuration on new Android Projects, this PR, changes the project build.gradle so it uses Maven Central instead of JCenter (and comment it as deprecated).